### PR TITLE
fix(app): removed GTC display due to alchemy api overuse

### DIFF
--- a/packages/react-app/src/components/Account.jsx
+++ b/packages/react-app/src/components/Account.jsx
@@ -77,16 +77,6 @@ export default function Account({
         <>
           <div className="flex items-center text-base justify-center">
             <>
-              <span className="mr-5 hover:text-gray-900">
-                <TokenBalance
-                  contracts={readContracts}
-                  img={"./gtcTokenLogo.svg"}
-                  contractName={"Token"}
-                  displayName={"GTC"}
-                  address={address}
-                  dollarMultiplier={null}
-                />
-              </span>
               <div className="hidden md:inline-flex">
                 <a
                   className="mr-5 hover:text-gray-900 flex flex-row"


### PR DESCRIPTION
We removed the <TokenBalance> component from the UI because it was making too many calls to alchemy w/ our increased traffic. There was no ticket associated w/ this. 